### PR TITLE
Electrophoresis

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,20 @@
         <span class="mdl-layout-title">Distribute</span>
 
         <nav class="mdl-navigation" id="feature-distribute">
-
+<!-- CK stuff-->
+            <div class="button_row">
+                <a id="anode_button" class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--raised feature-button">Anode</a>
+                <button id="anode_params_button" class="params-button mdl-button mdl-js-button mdl-button--icon">
+                    <i class="material-icons">settings</i>
+                </button>
+            </div>
+            <div class="button_row">
+                <a id="cathode_button" class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--raised feature-button">Cathode</a>
+                <button id="cathode_params_button" class="params-button mdl-button mdl-js-button mdl-button--icon">
+                    <i class="material-icons">settings</i>
+                </button>
+            </div>
+<!--end CK stuff-->
             <div class="button_row">
                 <a id="port_button" class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--raised feature-button">Port</a>
                 <button id="port_params_button" class="params-button mdl-button mdl-js-button mdl-button--icon">

--- a/src/app/featureSets/featureSet.js
+++ b/src/app/featureSets/featureSet.js
@@ -1,6 +1,8 @@
 import Device from "../core/device";
 
 import Port from "../library/port";
+import Anode from "../library/anode"; //new from CK
+import Cathode from "../library/cathode"; //new from CK
 import Channel from "../library/channel";
 import BetterMixer from "../library/betterMixer";
 import RotaryMixer from "../library/rotaryMixer";
@@ -35,6 +37,8 @@ export default class FeatureSet {
         //TODO: Replace this cumbersome mechanism for generating different feature variants, etc.
         this.__library = {
             Port: { object: new Port(), key: null },
+            Anode: { object: new Anode(), key: null },//ck addition
+            Cathode: { object: new Cathode(), key: null },//ck addition
             Channel: { object: new Channel(), key: null },
             BetterMixer: { object: new BetterMixer(), key: "FLOW" },
             RotaryMixer: { object: new RotaryMixer(), key: "FLOW" },

--- a/src/app/library/anode.js
+++ b/src/app/library/anode.js
@@ -1,0 +1,116 @@
+import Template from "./template";
+import paper from "paper";
+import ComponentPort from "../core/componentPort";
+
+export default class Anode extends Template {
+    constructor() {
+        super();
+    }
+
+    __setupDefinitions() {
+        this.__unique = {
+            position: "Point"
+        };
+
+        this.__heritable = {
+            anodeRadius: "Float",
+            pegHeight: "Float",
+            pegWidth: "Float",
+            height: "Float",
+            rotation: "Float"
+        };
+
+        this.__defaults = {
+            anodeRadius: 0.9 * 1000,
+            pegHeight: 0.2*1000,
+            pegWidth: 0.7*1000,
+            height: 1.1 * 1000,
+            rotation: 0
+        };
+
+        this.__units = {
+            anodeRadius: "&mu;m",
+            pegHeight: "&mu;m",
+            pegWidth: "&mu;m",
+            height: "&mu;m",
+            rotation: "&deg;"
+        };
+
+        this.__minimum = {
+            anodeRadius: 0.4 * 10,
+            pegHeight: 0.1*1000,
+            pegWidth: 0.1*1000,
+            height: 10,
+            rotation: 0
+        };
+
+        this.__maximum = {
+            anodeRadius: 2000,
+            pegHeight: 2*1000,
+            pegWidth: 2*1000,
+            height: 1200,
+            rotation: 90
+        };
+
+        this.__placementTool = "componentPositionTool";
+
+        this.__toolParams = {
+            position: "position"
+        };
+
+        this.__featureParams = {
+            position: "position",
+            anodeRadius: "anodeRadius",
+            pegHeight: "pegHeight",
+            pegWidth: "pegWidth",
+            rotation: "rotation"
+        };
+
+        this.__targetParams = {
+            anodeRadius: "anodeRadius",
+            pegHeight: "pegHeight",
+            pegWidth: "pegWidth",
+            rotation: "rotation"
+        };
+
+        this.__renderKeys = ["FLOW"];
+
+        this.__mint = "ANODE";
+    }
+
+    render2D(params, key) {
+        //Regardless of the key...
+        let position = params["position"];
+        let radius = params["anodeRadius"];
+        let pegheight = params["pegHeight"];
+        let pegwidth = params["pegWidth"];
+        let rotation = params["rotation"];
+        let color1 = params["color"];
+        let pos = new paper.Point(position[0], position[1]);
+        let outerCircle = new paper.Path.Circle(pos, radius);
+        outerCircle.fillColor = color1;
+
+        let peg = new paper.Path.Rectangle(
+            position[0]-pegwidth/2,position[1]-pegheight/2,
+            pegwidth,pegheight)
+	let finalCircle = outerCircle.subtract(peg);
+        finalCircle.fillColor = color1;
+        outerCircle.remove()
+        peg.remove()
+        return finalCircle.rotate(rotation, pos);
+    }
+
+    render2DTarget(key, params) {
+        let render = this.render2D(params, key);
+        render.fillColor.alpha = 0.5;
+        return render;
+    }
+
+    getPorts(params) {
+        let ports = [];
+
+        ports.push(new ComponentPort(0, 0, "1", "FLOW"));
+
+        return ports;
+    }
+}

--- a/src/app/library/cathode.js
+++ b/src/app/library/cathode.js
@@ -1,0 +1,120 @@
+import Template from "./template";
+import paper from "paper";
+import ComponentPort from "../core/componentPort";
+
+export default class Cahode extends Template {
+    constructor() {
+        super();
+    }
+
+    __setupDefinitions() {
+        this.__unique = {
+            position: "Point"
+        };
+
+        this.__heritable = {
+            cathodeRadius: "Float",
+            pegRadius: "Float",
+            pegThickness: "Float",
+            height: "Float",
+            rotation: "Float"
+        };
+
+        this.__defaults = {
+            cathodeRadius: 0.9 * 1000,
+            pegRadius: 0.7*1000,
+            pegThickness: 0.3*1000,
+            height: 1.1 * 1000,
+            rotation: 0
+        };
+
+        this.__units = {
+            cathodeRadius: "&mu;m",
+            pegRadius: "&mu;m",
+            pegThickness: "&mu;m",
+            height: "&mu;m",
+            rotation: "&deg;"
+        };
+
+        this.__minimum = {
+            cathodeRadius: 0.4 * 10,
+            pegRadius: 0.1*1000,
+            pegThickness: 0.1*1000,
+            height: 10,
+            rotation: 0
+        };
+
+        this.__maximum = {
+            cathodeRadius: 2000,
+            pegRadius: 2*1000,
+            pegThickness: 2*1000,
+            height: 1200,
+            rotation: 90
+        };
+
+        this.__placementTool = "componentPositionTool";
+
+        this.__toolParams = {
+            position: "position"
+        };
+
+        this.__featureParams = {
+            position: "position",
+            cathodeRadius: "cathodeRadius",
+            pegRadius: "pegRadius",
+            pegThickness: "pegThickness",
+            rotation: "rotation"
+        };
+
+        this.__targetParams = {
+            cathodeRadius: "cathodeRadius",
+            pegRadius: "pegRadius",
+            pegThickness: "pegThickness",
+            rotation: "rotation"
+        };
+
+        this.__renderKeys = ["FLOW"];
+
+        this.__mint = "CATHODE";
+    }
+
+    render2D(params, key) {
+        //Regardless of the key...
+        let position = params["position"];
+        let radius = params["cathodeRadius"];
+        let pegradius = params["pegRadius"];
+        let pegthickness = params["pegThickness"];
+        let rotation = params["rotation"];
+        let color1 = params["color"];
+        let pos = new paper.Point(position[0], position[1]);
+        let outerCircle = new paper.Path.Circle(pos, radius);
+        outerCircle.fillColor = color1;
+
+        let peg1 = new paper.Path.Rectangle(
+            position[0]-pegradius/2,position[1]-pegthickness/2,
+            pegradius,pegthickness)
+        let peg2 = new paper.Path.Rectangle(
+            position[0]-pegthickness/2,position[1]-pegradius/2,
+            pegthickness,pegradius)
+	let finalCircle = outerCircle.subtract(peg1.unite(peg2));
+        finalCircle.fillColor = color1;
+        outerCircle.remove()
+        peg1.remove()
+	peg2.remove()
+        return finalCircle.rotate(rotation, pos);
+    }
+
+    render2DTarget(key, params) {
+        let render = this.render2D(params, key);
+        render.fillColor.alpha = 0.5;
+        return render;
+    }
+
+    getPorts(params) {
+        let ports = [];
+
+        ports.push(new ComponentPort(0, 0, "1", "FLOW"));
+
+        return ports;
+    }
+}

--- a/src/app/view/ui/componentToolBar.js
+++ b/src/app/view/ui/componentToolBar.js
@@ -28,6 +28,8 @@ export default class ComponentToolBar {
         this.__pumpButton = document.getElementById("pump_button");
         this.__pump3dButton = document.getElementById("pump3d_button");
         this.__portButton = document.getElementById("port_button");
+        this.__anodeButton = document.getElementById("anode_button");//CK edit
+        this.__cathodeButton = document.getElementById("cathode_button");//CK
         this.__viaButton = document.getElementById("via_button");
         this.__chamberButton = document.getElementById("chamber_button");
         this.__diamondButton = document.getElementById("diamond_button");
@@ -58,6 +60,8 @@ export default class ComponentToolBar {
         this.__pumpParams = document.getElementById("pump_params_button");
         this.__pump3dParams = document.getElementById("pump3d_params_button");
         this.__portParams = document.getElementById("port_params_button");
+        this.__anodeParams = document.getElementById("anode_params_button");//ck
+        this.__cathodeParams = document.getElementById("cathode_params_button");//ck
         this.__viaParams = document.getElementById("via_params_button");
         this.__chamberParams = document.getElementById("chamber_params_button");
         this.__diamondParams = document.getElementById("diamond_params_button");
@@ -87,6 +91,8 @@ export default class ComponentToolBar {
             Transition: this.__transitionButton,
             Via: this.__viaButton,
             Port: this.__portButton,
+            Anode: this.__anodeButton,//ck
+            Cathode: this.__cathodeButton,//ck
             CircleValve: this.__circleValveButton,
             Valve3D: this.__valve3dButton,
             Valve: this.__valveButton,
@@ -198,6 +204,20 @@ export default class ComponentToolBar {
             ref.setActiveButton("Port");
             ref.__viewManagerDelegate.switchTo2D();
         };
+        
+        this.__anodeButton.onclick = function() {//ck
+            Registry.viewManager.activateTool("Anode");//ck
+
+            ref.setActiveButton("Anode");//ck
+            ref.__viewManagerDelegate.switchTo2D();//ck
+        };//ck
+
+        this.__cathodeButton.onclick = function() {//ck
+            Registry.viewManager.activateTool("Cathode");//ck
+
+            ref.setActiveButton("Cathode");//ck
+            ref.__viewManagerDelegate.switchTo2D();//ck
+        };//ck
 
         // this.__viaButton.onclick = function() {
         //     Registry.viewManager.activateTool("Via");
@@ -335,6 +355,8 @@ export default class ComponentToolBar {
         this.__pump3dParams.onclick = ComponentToolBar.getParamsWindowCallbackFunction("Pump3D", "Basic");
         this.__pumpParams.onclick = ComponentToolBar.getParamsWindowCallbackFunction("Pump", "Basic");
         this.__portParams.onclick = ComponentToolBar.getParamsWindowCallbackFunction("Port", "Basic");
+        this.__anodeParams.onclick = ComponentToolBar.getParamsWindowCallbackFunction("Anode", "Basic");//ck
+        this.__cathodeParams.onclick = ComponentToolBar.getParamsWindowCallbackFunction("Cathode", "Basic");//ck
         // this.__viaParams.onclick = ComponentToolBar.getParamsWindowCallbackFunction("Via", "Basic");
         this.__chamberParams.onclick = ComponentToolBar.getParamsWindowCallbackFunction("Chamber", "Basic");
         this.__diamondParams.onclick = ComponentToolBar.getParamsWindowCallbackFunction("DiamondReactionChamber", "Basic");

--- a/src/app/view/viewManager.js
+++ b/src/app/view/viewManager.js
@@ -896,6 +896,8 @@ export default class ViewManager {
         this.tools["RectValve"] = new ComponentPositionTool("RectValve", "Basic");
         this.tools["Valve3D"] = new ValveInsertionTool("Valve3D", "Basic", true);
         this.tools["Port"] = new ComponentPositionTool("Port", "Basic");
+        this.tools["Anode"] = new ComponentPositionTool("Anode", "Basic");//Ck
+        this.tools["Cathode"] = new ComponentPositionTool("Cathode", "Basic");//Ck
         this.tools["Via"] = new PositionTool("Via", "Basic");
         this.tools["DiamondReactionChamber"] = new ComponentPositionTool("DiamondReactionChamber", "Basic");
         this.tools["BetterMixer"] = new ComponentPositionTool("BetterMixer", "Basic");


### PR DESCRIPTION
Add anode and cathode for electrophoresis on a chip. The parts are based on the port since a wire will need to be inserted. They include pegs that can either be placeholders for a wire or a scaffold to wrap it around.