### PR TITLE
Refactored dialogs to use a base dialog component

### DIFF
--- a/public/modified.css
+++ b/public/modified.css
@@ -17,7 +17,6 @@
 }
 
 .button_row {
-	position: relative;
 	width: 100%;
 }
 
@@ -60,10 +59,9 @@
 
 .feature-button {
 	display: block;
-	width: auto;
+  width: auto;
 	margin-left: 15px;
 	margin-right: 15px;
-	margin-bottom: 15px;
 	margin-top: 0;
 }
 

--- a/src/components/Dialog.vue
+++ b/src/components/Dialog.vue
@@ -1,0 +1,61 @@
+<template>
+  <v-dialog v-model="dialog" persistent max-width="600">
+    <template v-slot:activator="{ on, attrs }">
+      <v-btn v-bind="attrs" v-on="on" :id="buttonID" :class="buttonClasses">{{ title }}</v-btn>
+    </template>
+    <v-card>
+      <v-card-title class="headline">{{ title }}</v-card-title>
+      <v-card-text>
+        <slot name="content">Dialog content goes here</slot>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <slot name="actions" v-bind:callbacks="callbacks">
+          <v-btn color="green darken-1" text @click="callbacks.close()">Close</v-btn>
+        </slot>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<style lang="sass" scoped>
+</style>
+
+<script lang="ts">
+import Vue from "vue"
+export default {
+    props: {
+      title: String,
+      color: String,
+      textColor: String
+    },
+    data(){
+        return {
+            dialog: false,
+            callbacks: {}
+        }
+    },
+    mounted() {
+        // Here we set ouf default callbacks for the dialog in mounted to ensure the properties exist in the slot scope
+        // when called by the children. Setting this up in data would result in undefined slot scope values
+        Vue.set(this.callbacks, "close", callback => {
+            if (callback) callback();
+            this.dialog = false;
+        });
+    },
+    computed: {
+      buttonID: function() {
+        return this.title.toLowerCase().replace(" ", "_") + "_dialog_button"
+      },
+      buttonClasses: function() {
+        return [
+        (this.color && this.color.length > 0) ? this.color : "white",
+        (this.textColor && this.textColor.length > 0) ? this.textColor : "blue--text",
+        'mb-2',
+        'feature-button',
+        'button-row'
+        ]
+      }
+  }
+}
+</script>

--- a/src/components/EditBorderDialog.vue
+++ b/src/components/EditBorderDialog.vue
@@ -1,39 +1,37 @@
 <template>
-    <v-row justify="center">
-        <v-dialog v-model="dialog" persistent max-width="600">
-            <template v-slot:activator="{ on, attrs }">
-                <div color="primary" dark v-bind="attrs" v-on="on" class="button_row">
-                    <a id="edit_border_button" class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--raised feature-button"> Edit Border</a>
-                </div>
-            </template>
-            <v-card>
-                <v-card-title class="headline"> Edit Device Border </v-card-title>
-                <v-card-text>
-                    <h4>Drag Drop the DXF file containing border to import:</h4>
-                    <div class="mdl-dialog__content">
-                        <canvas id="border_import_panel" tabindex="1" width="300" height="200"></canvas>
-                        <br />
-                        <input type="file" class="upload" id="dxf_input" />
-                    </div>
-                </v-card-text>
-                <v-card-actions>
-                    <v-spacer></v-spacer>
-                    <v-btn color="green darken-1" text @click="dialog = false"> Import Borde </v-btn>
-                    <v-btn color="green darken-1" text @click="dialog = false"> Delete Border </v-btn>
-                    <v-btn color="green darken-1" text @click="dialog = false"> Save </v-btn>
-                    <v-btn color="green darken-1" text @click="dialog = false"> Cancel </v-btn>
-                </v-card-actions>
-            </v-card>
-        </v-dialog>
-    </v-row>
+  <Dialog title="Edit Border">
+    <template #content>
+      <h4>Drag Drop the DXF file containing border to import:</h4>
+      <div class="mdl-dialog__content">
+          <canvas id="border_import_panel" tabindex="1" width="300" height="200"></canvas>
+          <br />
+          <input type="file" class="upload" id="dxf_input" />
+      </div>
+    </template>
+    <template v-slot:actions="{ callbacks }">
+        <v-btn color="green darken-1" text @click="callbacks.close()">Import Border</v-btn>
+        <v-btn color="green darken-1" text @click="callbacks.close()">Delete Border</v-btn>
+        <v-btn color="green darken-1" text @click="callbacks.close(onSave)">Save</v-btn>
+        <v-btn color="green darken-1" text @click="callbacks.close()">Cancel</v-btn>
+    </template>
+ </Dialog>
 </template>
 
 <script>
+import Dialog from "@/components/Dialog.vue"
 export default {
+    components: {
+      Dialog
+    },
     data() {
         return {
             dialog: false
         };
+    },
+    methods: {
+      onSave() {
+        console.log("Saved data for Edit Border")
+      }
     }
 };
 </script>

--- a/src/components/EditDeviceDialog.vue
+++ b/src/components/EditDeviceDialog.vue
@@ -1,5 +1,34 @@
 <template>
-    <v-dialog v-model="dialog" persistent max-width="600">
+  <Dialog title="Edit Device">
+    <template v-slot:content>
+          <h4>Rename:</h4>
+          <form action="#">
+              <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                  <input class="mdl-textfield__input" type="text" id="devicename_textinput" />
+                  <label class="mdl-textfield__label" for="devicename_textinput">Device Name</label>
+              </div>
+          </form>
+
+          <h4>Resize:</h4>
+          <form action="#">
+              <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                  <input class="mdl-textfield__input" type="text" pattern="-?[0-9]*(\.[0-9]+)?" id="xspan_textinput" />
+                  <label class="mdl-textfield__label" for="xspan_textinput">X-Span (mm)</label>
+                  <span class="mdl-textfield__error">Input is not a number!</span>
+              </div>
+              <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                  <input class="mdl-textfield__input" type="text" pattern="-?[0-9]*(\.[0-9]+)?" id="yspan_textinput" />
+                  <label class="mdl-textfield__label" for="yspan_textinput">Y-Span (mm)</label>
+                  <span class="mdl-textfield__error">Input is not a number!</span>
+              </div>
+          </form>
+    </template>
+    <template v-slot:actions="{ callbacks }">
+      <v-btn color="green darken-1" text @click="callbacks.close()"> Cancel </v-btn>
+      <v-btn color="green darken-1" text @click="callbacks.close(onSave)">Save</v-btn>
+    </template>
+  </Dialog>
+ <!-- <v-dialog v-model="dialog" persistent max-width="600">
         <template v-slot:activator="{ on, attrs }">
             <div color="primary" dark v-bind="attrs" v-on="on" class="button_row">
                 <a id="resize_button" class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--raised feature-button"> Edit Device</a>
@@ -8,27 +37,27 @@
         <v-card>
             <v-card-title class="headline"> Edit Device </v-card-title>
             <v-card-text>
-                <h4>Rename:</h4>
-                <form action="#">
-                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                        <input class="mdl-textfield__input" type="text" id="devicename_textinput" />
-                        <label class="mdl-textfield__label" for="devicename_textinput">Device Name</label>
-                    </div>
-                </form>
+          <h4>Rename:</h4>
+          <form action="#">
+              <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                  <input class="mdl-textfield__input" type="text" id="devicename_textinput" />
+                  <label class="mdl-textfield__label" for="devicename_textinput">Device Name</label>
+              </div>
+          </form>
 
-                <h4>Resize:</h4>
-                <form action="#">
-                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                        <input class="mdl-textfield__input" type="text" pattern="-?[0-9]*(\.[0-9]+)?" id="xspan_textinput" />
-                        <label class="mdl-textfield__label" for="xspan_textinput">X-Span (mm)</label>
-                        <span class="mdl-textfield__error">Input is not a number!</span>
-                    </div>
-                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                        <input class="mdl-textfield__input" type="text" pattern="-?[0-9]*(\.[0-9]+)?" id="yspan_textinput" />
-                        <label class="mdl-textfield__label" for="yspan_textinput">Y-Span (mm)</label>
-                        <span class="mdl-textfield__error">Input is not a number!</span>
-                    </div>
-                </form>
+          <h4>Resize:</h4>
+          <form action="#">
+              <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                  <input class="mdl-textfield__input" type="text" pattern="-?[0-9]*(\.[0-9]+)?" id="xspan_textinput" />
+                  <label class="mdl-textfield__label" for="xspan_textinput">X-Span (mm)</label>
+                  <span class="mdl-textfield__error">Input is not a number!</span>
+              </div>
+              <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                  <input class="mdl-textfield__input" type="text" pattern="-?[0-9]*(\.[0-9]+)?" id="yspan_textinput" />
+                  <label class="mdl-textfield__label" for="yspan_textinput">Y-Span (mm)</label>
+                  <span class="mdl-textfield__error">Input is not a number!</span>
+              </div>
+          </form>
             </v-card-text>
             <v-card-actions>
                 <v-spacer></v-spacer>
@@ -36,14 +65,23 @@
                 <v-btn color="green darken-1" text @click="dialog = false"> Save </v-btn>
             </v-card-actions>
         </v-card>
-    </v-dialog>
+    </v-dialog> -->
 </template>
 <script>
+import Dialog from "@/components/Dialog.vue"
 export default {
+    components: {
+      Dialog
+    },
     data() {
         return {
             dialog: false
         };
+    },
+    methods: {
+      onSave() {
+        console.log("Saved data for Edit Device")
+      }
     }
 };
 </script>

--- a/src/components/ImportDXFDialog.vue
+++ b/src/components/ImportDXFDialog.vue
@@ -1,46 +1,43 @@
 <template>
-    <v-dialog v-model="dialog" persistent max-width="600">
-        <template v-slot:activator="{ on, attrs }">
-            <a
-                color="primary"
-                dark
-                v-bind="attrs"
-                v-on="on"
-                id="show_import_dialog"
-                class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--raised feature-button mdl-button--colored"
-                >Import</a
-            >
-        </template>
-        <v-card>
-            <v-card-title class="headline"> Drag and drop the DXF file on the canvas </v-card-title>
-            <v-card-text>
-                <div class="mdl-dialog__content">
-                    <canvas id="component_preview_canvas" tabindex="1" width="500" height="400"></canvas>
-                </div>
-                <form action="#">
-                    <div class="mdl-textfield mdl-js-textfield" width="300px">
-                        <input class="mdl-textfield__input" type="text" id="new_component_name" />
-                        <label class="mdl-textfield__label" for="new_component_name">Name...</label>
-                    </div>
-                </form>
-            </v-card-text>
-            <v-card-actions>
-                <v-spacer></v-spacer>
-                <v-btn color="green darken-1" text @click="dialog = false"> Cancel </v-btn>
-                <v-btn color="green darken-1" text @click="dialog = false"> Import </v-btn>
-            </v-card-actions>
-        </v-card>
-    </v-dialog>
+    <Dialog 
+      title="Import" 
+      color="primary"
+      textColor="white--text">
+      <template #content>
+      <div class="mdl-dialog__content">
+          <canvas id="component_preview_canvas" tabindex="1" width="500" height="400"></canvas>
+      </div>
+      <form action="#">
+          <div class="mdl-textfield mdl-js-textfield" width="300px">
+              <input class="mdl-textfield__input" type="text" id="new_component_name" />
+              <label class="mdl-textfield__label" for="new_component_name">Name...</label>
+          </div>
+      </form>
+      </template>
+      <template #actions="{ callbacks }">
+      <v-btn color="green darken-1" text @click="callbacks.close()"> Cancel </v-btn>
+      <v-btn color="green darken-1" text @click="callbacks.close()"> Import </v-btn>
+      </template>
+    </Dialog>
 </template>
 
 <script>
-export default {
-    data() {
-        return {
-            dialog: false
-        };
-    }
-};
+  import Dialog from "@/components/Dialog.vue"
+  export default {
+      components: {
+        Dialog
+      },
+      data() {
+          return {
+              dialog: false
+          };
+      },
+      methods: {
+        onSave() {
+          console.log("Saved data for Edit Device")
+        }
+      }
+  };
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/InsertTextDialog.vue
+++ b/src/components/InsertTextDialog.vue
@@ -1,40 +1,36 @@
 <template>
-    <v-dialog v-model="dialog" persistent max-width="600">
-        <template v-slot:activator="{ on, attrs }">
-            <div class="button_row">
-                <a color="primary" dark v-bind="attrs" v-on="on" id="insert_text_button" class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--raised feature-button">
-                    Insert Text</a
-                >
-            </div>
-        </template>
-        <v-card>
-            <v-card-title class="headline"> Insert Text: </v-card-title>
-            <v-card-text>
-                <form action="#">
-                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-                        <input class="mdl-textfield__input" type="text" id="inserttext_textinput" />
-                        <label class="mdl-textfield__label" for="inserttext_textinput">Text</label>
-                    </div>
-                </form>
-            </v-card-text>
-            <v-card-actions>
-                <v-spacer></v-spacer>
-                <v-btn color="green darken-1" text @click="dialog = false"> Cancel </v-btn>
-                <v-btn color="green darken-1" text @click="dialog = false"> Insert </v-btn>
-            </v-card-actions>
-        </v-card>
-    </v-dialog>
+  <Dialog title="Insert Text">
+    <template #content>
+    <form action="#">
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+          <input class="mdl-textfield__input" type="text" id="inserttext_textinput" />
+          <label class="mdl-textfield__label" for="inserttext_textinput">Text</label>
+        </div>
+      </form>
+      </template>
+      <template v-slot:actions="{ callbacks }">
+          <v-spacer></v-spacer>
+          <v-btn color="green darken-1" text @click="callbacks.close()"> Cancel </v-btn>
+          <v-btn color="green darken-1" text @click="callbacks.close()"> Insert </v-btn>
+      </template>
+    </Dialog>
 </template>
 
 <script>
-export default {
-    data() {
-        return {
-            dialog: false
-        };
-    }
-};
+  import Dialog from "@/components/Dialog.vue"
+  export default {
+      components: {
+        Dialog
+      },
+      data() {
+          return {
+              dialog: false
+          };
+      },
+      methods: {
+        onSave() {
+          console.log("Saved data for Edit Device")
+        }
+      }
+  };
 </script>
-
-<style lang="scss" scoped>
-</style>

--- a/src/views/layouts/sidebar_layout.vue
+++ b/src/views/layouts/sidebar_layout.vue
@@ -1,18 +1,21 @@
 <template>
     <div>
         <v-navigation-drawer app permanent class="pt-4" color="grey lighten-3">
-            <v-img class="mx-auto" src="img/logo.png" alt="3DuF Logo" style="width: 90%" />
+            <div class="d-flex flex-column mx-2"> 
+              <v-img class="mx-auto" src="img/logo.png" alt="3DuF Logo" style="width: 90%" />
+              <v-divider class="mb-1"></v-divider>
+              <IntroHelpDialog />
+              <HelpDialog />
+              <v-divider></v-divider>
+              <EditDeviceDialog />
+              <EditBorderDialog />
+              <InsertTextDialog />
+              <ImportDXFDialog />
+              <v-divider></v-divider>
+              <LayerToolbar />
+              <ComponentToolbar />
+            </div>
 
-            <v-divider></v-divider>
-            <IntroHelpDialog />
-
-            <v-divider></v-divider>
-            <EditDeviceDialog />
-            <EditBorderDialog />
-            <InsertTextDialog />
-            <ImportDXFDialog />
-            <LayerToolbar />
-            <ComponentToolbar />
             <v-list>
                 <v-list-item-group mandatory color="indigo">
                     <v-list-item v-for="[icon, text] in buttons" :key="icon" link>
@@ -26,7 +29,6 @@
                     </v-list-item>
                 </v-list-item-group>
             </v-list>
-            <HelpDialog />
         </v-navigation-drawer>
 
         <v-main id="visualizer-slot">
@@ -43,14 +45,14 @@
 </style>
 
 <script>
-import HelpDialog from "../../components/HelpDialog.vue";
-import IntroHelpDialog from "../../components/IntroHelpDialog.vue";
-import EditDeviceDialog from "../../components/EditDeviceDialog.vue";
-import EditBorderDialog from "../../components/EditBorderDialog.vue";
-import ImportDXFDialog from "../../components/ImportDXFDialog.vue";
-import InsertTextDialog from "../../components/InsertTextDialog.vue";
-import LayerToolbar from "../../components/LayerToolbar.vue";
-import ComponentToolbar from "../../components/ComponentToolBar.vue";
+import HelpDialog from "@/components/HelpDialog.vue";
+import IntroHelpDialog from "@/components/IntroHelpDialog.vue";
+import EditDeviceDialog from "@/components/EditDeviceDialog.vue";
+import EditBorderDialog from "@/components/EditBorderDialog.vue";
+import ImportDXFDialog from "@/components/ImportDXFDialog.vue";
+import InsertTextDialog from "@/components/InsertTextDialog.vue";
+import LayerToolbar from "@/components/LayerToolbar.vue";
+import ComponentToolbar from "@/components/ComponentToolBar.vue";
 export default {
     components: {
         HelpDialog,
@@ -73,7 +75,6 @@ export default {
             ]
         };
     },
-    methods: {
-    }
+    methods: {}
 };
 </script>


### PR DESCRIPTION
Added a base dialog component and refactored the other "fire and forget" to use it.

This greatly simplifies new fire and forget components, while also allowing the common dialog view to be updated from a single source.

The look and feel is slightly different but is an effect of using Vuetify's version of buttons. We can configure the exact look and feel later, however they currently play a lot better with the new layout given to the sidebar.

There are a couple instances of other elements having icon images that have moved due to the introduction of d-flex in the side bar, but an upcoming commit will fix that.