### PR TITLE
Grid size

### DIFF
--- a/src/components/ResolutionToolbar.vue
+++ b/src/components/ResolutionToolbar.vue
@@ -71,7 +71,7 @@ export default {
         };
     },
     created() {
-        console.log("bus testing");
+        // listen to ZoomSlider and get grid size data and show here as sliderValue
         EventBus.get().on(EventBus.UPDATE_GRID, data => {
             this.sliderValue = data;
         });
@@ -106,12 +106,10 @@ export default {
             }
         },
         updateGrid(event) {
-            console.log("updatedGrid testung");
             let registryref = Registry;
             const { values } = event;
             let spacingchanges = registryref.currentGrid.__spacing;
             let value1 = parseInt(values[0], 10);
-            console.log("updatedGrid testing value1", value1);
             //This ensures that there is something valid present
             if (registryref.currentGrid !== null) {
                 registryref.currentGrid.updateGridSpacing(value1);

--- a/src/components/ResolutionToolbar.vue
+++ b/src/components/ResolutionToolbar.vue
@@ -18,6 +18,12 @@
 </template>
 
 <script>
+// Issues: Beining Aug.5.21
+// Grid Settings hover no show;
+// Grid Settings slider out of range???
+// "console log : Could not set the Zoom, could be in the ZoomSlider.vue??";
+// Grid_size doesn't change with zoom slider,need to figure out how this work.
+
 import veeno from "veeno";
 import "nouislider/distribute/nouislider.min.css";
 import Registry from "../app/core/registry";

--- a/src/components/ResolutionToolbar.vue
+++ b/src/components/ResolutionToolbar.vue
@@ -13,7 +13,7 @@
             </v-switch>
             <veeno ref="slider" v-model="sliderValue" :disabled="slider_enabled" v-bind="sliderOptions" @change="updateGrid" />
         </div>
-        <div id="bottom-info-bar">Grid Size: {{ updatedsliderValue }} &mu;m</div>
+        <div id="bottom-info-bar">Grid Size: {{ sliderValue }} &mu;m</div>
     </div>
 </template>
 
@@ -37,7 +37,7 @@ export default {
     },
 
     props: {
-        updatedsliderValue: {
+        sliderValue: {
             type: Number,
             default: 1000
         }
@@ -59,7 +59,7 @@ export default {
     created() {
         console.log("bus testing");
         EventBus.get().on(EventBus.UPDATE_GRID, data => {
-            this.updatedsliderValue = data;
+            this.sliderValue = data;
         });
     },
     updated() {

--- a/src/components/ResolutionToolbar.vue
+++ b/src/components/ResolutionToolbar.vue
@@ -13,7 +13,7 @@
             </v-switch>
             <veeno ref="slider" v-model="sliderValue" :disabled="slider_enabled" v-bind="sliderOptions" @change="updateGrid" />
         </div>
-        <div id="bottom-info-bar">Grid Size: {{ sliderValue }} &mu;m</div>
+        <div id="bottom-info-bar">Grid Size: {{ sliderValue1 }} &mu;m</div>
     </div>
 </template>
 
@@ -28,6 +28,7 @@ import veeno from "veeno";
 import "nouislider/distribute/nouislider.min.css";
 import Registry from "../app/core/registry";
 import wNumb from "wnumb";
+import EventBus from "@/events/events";
 
 export default {
     name: "ResolutionToolbar",
@@ -35,7 +36,12 @@ export default {
         veeno
     },
 
-    props: {},
+    props: {
+        sliderValue1: {
+            type: Number,
+            default: 1000
+        }
+    },
     data() {
         return {
             activated: false,
@@ -49,6 +55,12 @@ export default {
                 range: { min: [1], "10%": [10], "30%": [100], "90%": [1000], max: [5000] }
             }
         };
+    },
+    created() {
+        console.log("bus testing");
+        EventBus.get().on(EventBus.UPDATE_GRID, data => {
+            this.sliderValue1 = data;
+        });
     },
     updated() {
         Registry.currentGrid.enableAdaptiveGrid();
@@ -83,8 +95,12 @@ export default {
             console.log("updatedGrid testung");
             let registryref = Registry;
             const { values } = event;
+            let spacingchanges = registryref.currentGrid.__spacing;
             let value1 = parseInt(values[0], 10);
+            console.log("updatedGrid testung", spacingchanges);
             //This ensures that there is something valid present
+            this.sliderValue1 = spacingchanges;
+            console.log("updatedGrid testung2", this.sliderValue1);
             if (registryref.currentGrid !== null) {
                 registryref.currentGrid.updateGridSpacing(value1);
                 registryref.currentGrid.notifyViewManagerToUpdateView();

--- a/src/components/ResolutionToolbar.vue
+++ b/src/components/ResolutionToolbar.vue
@@ -34,7 +34,6 @@ export default {
         return {
             activated: false,
             hover: false,
-            labeltext: 1000,
             slider_enabled: true,
             switch2: true,
             sliderOptions: {

--- a/src/components/ResolutionToolbar.vue
+++ b/src/components/ResolutionToolbar.vue
@@ -11,8 +11,9 @@
             <v-switch v-model="switch2" color="#304FFE" @change="clickedSnap">
                 <template v-slot:label class="mdl-switch__label">Render Snap Points</template>
             </v-switch>
-            <veeno ref="slider" :disabled="slider_enabled" v-bind="sliderOptions" @change="updateGrid" />
+            <veeno ref="slider" v-model="sliderValue" :disabled="slider_enabled" v-bind="sliderOptions" @change="updateGrid" />
         </div>
+        <div id="bottom-info-bar">Grid Size: {{ sliderValue }} &mu;m</div>
     </div>
 </template>
 
@@ -33,6 +34,7 @@ export default {
         return {
             activated: false,
             hover: false,
+            labeltext: 1000,
             slider_enabled: true,
             switch2: true,
             sliderOptions: {
@@ -73,6 +75,7 @@ export default {
             }
         },
         updateGrid(event) {
+            console.log("updatedGrid testung");
             let registryref = Registry;
             const { values } = event;
             let value1 = parseInt(values[0], 10);
@@ -80,6 +83,15 @@ export default {
             if (registryref.currentGrid !== null) {
                 registryref.currentGrid.updateGridSpacing(value1);
                 registryref.currentGrid.notifyViewManagerToUpdateView();
+            }
+        },
+        updateResolutionLabelAndSlider(smallResolution) {
+            console.log("updatedlable testung");
+            if (smallResolution !== null) {
+                this.__gridResolution = smallResolution;
+                this.__smallresolutionLabel.innerHTML = smallResolution + " &mu;m";
+
+                this.__gridResolutionSlider.noUiSlider.set(parseInt(smallResolution, 10));
             }
         }
     }
@@ -122,5 +134,11 @@ export default {
 .veeno.noUi-pips.noUi-pips-horizontal {
     padding: 0px;
     left: 10px;
+}
+#bottom-info-bar {
+    z-index: 9;
+    bottom: 2px;
+    right: 50px;
+    position: absolute;
 }
 </style>

--- a/src/components/ResolutionToolbar.vue
+++ b/src/components/ResolutionToolbar.vue
@@ -13,7 +13,7 @@
             </v-switch>
             <veeno ref="slider" v-model="sliderValue" :disabled="slider_enabled" v-bind="sliderOptions" @change="updateGrid" />
         </div>
-        <div id="bottom-info-bar">Grid Size: {{ sliderValue1 }} &mu;m</div>
+        <div id="bottom-info-bar">Grid Size: {{ updatedsliderValue }} &mu;m</div>
     </div>
 </template>
 
@@ -37,7 +37,7 @@ export default {
     },
 
     props: {
-        sliderValue1: {
+        updatedsliderValue: {
             type: Number,
             default: 1000
         }
@@ -59,7 +59,7 @@ export default {
     created() {
         console.log("bus testing");
         EventBus.get().on(EventBus.UPDATE_GRID, data => {
-            this.sliderValue1 = data;
+            this.updatedsliderValue = data;
         });
     },
     updated() {
@@ -97,17 +97,14 @@ export default {
             const { values } = event;
             let spacingchanges = registryref.currentGrid.__spacing;
             let value1 = parseInt(values[0], 10);
-            console.log("updatedGrid testung", spacingchanges);
+            console.log("updatedGrid testing value1", value1);
             //This ensures that there is something valid present
-            this.sliderValue1 = spacingchanges;
-            console.log("updatedGrid testung2", this.sliderValue1);
             if (registryref.currentGrid !== null) {
                 registryref.currentGrid.updateGridSpacing(value1);
                 registryref.currentGrid.notifyViewManagerToUpdateView();
             }
         },
         updateResolutionLabelAndSlider(smallResolution) {
-            console.log("updatedlable testung");
             if (smallResolution !== null) {
                 this.__gridResolution = smallResolution;
                 this.__smallresolutionLabel.innerHTML = smallResolution + " &mu;m";

--- a/src/components/ResolutionToolbar.vue
+++ b/src/components/ResolutionToolbar.vue
@@ -1,8 +1,22 @@
 <template>
     <div>
-        <v-btn id="grid-button" class="pink white--text" fab @click="showProperties()" @mouseenter.native="hover = true" @mouseleave.native="hover = false">
-            <span class="material-icons">grid_on</span>
-        </v-btn>
+        <v-tooltip left>
+            <template v-slot:activator="{ on, attrs }">
+                <v-btn
+                    id="grid-button"
+                    v-bind="attrs"
+                    class="pink white--text"
+                    fab
+                    v-on="on"
+                    @click="showProperties()"
+                    @mouseenter.native="hover = true"
+                    @mouseleave.native="hover = false"
+                >
+                    <span class="material-icons">grid_on</span>
+                </v-btn>
+            </template>
+            <span>Grid Settings</span>
+        </v-tooltip>
         <v-btn v-if="hover" id="grid-hover" class="grey white--text" x-small depressed>Grid Settings</v-btn>
         <div v-if="activated" id="resolution-toolbar">
             <v-switch v-model="slider_enabled" color="#304FFE" hide-details @change="clickedGrid">

--- a/src/components/ZoomSlider.vue
+++ b/src/components/ZoomSlider.vue
@@ -7,6 +7,7 @@ import Registry from "@/app/core/registry";
 import noUiSlider from "nouislider";
 import "@/assets/nouislider/nouislider.min.css";
 import EventBus from "@/events/events";
+import Vue from "vue";
 
 export default {
     name: "ZoomSlider",
@@ -40,7 +41,10 @@ export default {
         this.$refs.slider.noUiSlider.on("update", function(values, handle, unencoded, tap, positions) {
             if (ref.isUserGeneratedEvent) {
                 console.log("Zoom Value:", values[0]);
+                const num = Registry.currentGrid.__spacing;
+                console.log("Zoom Value testing num", num);
                 // TODO - Map this directly to the zoom functions
+                EventBus.get().emit(EventBus.UPDATE_GRID, num);
                 console.log(registryref);
                 try {
                     registryref.viewManager.setZoom(ref.convertLinearToZoomScale(values[0]));
@@ -50,7 +54,6 @@ export default {
             }
             ref.isUserGeneratedEvent = true;
         });
-
         EventBus.get().on(EventBus.UPDATE_ZOOM, this.setZoom);
     },
     methods: {
@@ -63,10 +66,17 @@ export default {
             this.$$refs.slider.noUiSlider.set(this.convertZoomtoLinearScale(zoom));
         },
         convertLinearToZoomScale(linvalue) {
+            console.log("convertLinearToZoomScale", Math.pow(10, linvalue));
             return Math.pow(10, linvalue);
         },
         convertZoomtoLinearScale(zoomvalue) {
+            console.log("convertZoomtoLinearScale", Math.log10(zoomvalue));
             return Math.log10(zoomvalue);
+        },
+        created() {
+            console.log("Zoombustesting");
+            const num = Registry.currentGrid.__spacing;
+            EventBus.$emit("GridSizeUpgrade", num);
         }
     }
 };

--- a/src/components/ZoomSlider.vue
+++ b/src/components/ZoomSlider.vue
@@ -1,7 +1,7 @@
 <template>
     <div ref="slider" class="zoomsliderbase"></div>
 </template>
-å
+
 <script>
 import Registry from "@/app/core/registry";
 import noUiSlider from "nouislider";

--- a/src/components/ZoomSlider.vue
+++ b/src/components/ZoomSlider.vue
@@ -41,10 +41,10 @@ export default {
         this.$refs.slider.noUiSlider.on("update", function(values, handle, unencoded, tap, positions) {
             if (ref.isUserGeneratedEvent) {
                 console.log("Zoom Value:", values[0]);
-                const num = Registry.currentGrid.__spacing;
-                console.log("Zoom Value testing num", num);
+                const updatedSpacing = Registry.currentGrid.__spacing;
                 // TODO - Map this directly to the zoom functions
-                EventBus.get().emit(EventBus.UPDATE_GRID, num);
+                EventBus.get().emit(EventBus.UPDATE_GRID, updatedSpacing);
+                // EventBus emit updated spacing, ResolutionToolBar.vue listen to this
                 console.log(registryref);
                 try {
                     registryref.viewManager.setZoom(ref.convertLinearToZoomScale(values[0]));
@@ -66,17 +66,10 @@ export default {
             this.$$refs.slider.noUiSlider.set(this.convertZoomtoLinearScale(zoom));
         },
         convertLinearToZoomScale(linvalue) {
-            console.log("convertLinearToZoomScale", Math.pow(10, linvalue));
             return Math.pow(10, linvalue);
         },
         convertZoomtoLinearScale(zoomvalue) {
-            console.log("convertZoomtoLinearScale", Math.log10(zoomvalue));
             return Math.log10(zoomvalue);
-        },
-        created() {
-            console.log("Zoombustesting");
-            const num = Registry.currentGrid.__spacing;
-            EventBus.$emit("GridSizeUpgrade", num);
         }
     }
 };

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -22,6 +22,7 @@ class EventBus extends EventEmitter {
     static RIGHT_CLICK = "right_click";
     static CLOSE_ALL_WINDOWS = "close_all_windows";
     static UPDATE_ZOOM = "update_zoom";
+    static UPDATE_GRID = "update_grid";
 }
 
 export default EventBus;

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import "roboto-fontface/css/roboto/roboto-fontface.css";
 import "@mdi/font/css/materialdesignicons.css";
 import Vuetify from "vuetify";
 
+Vue.prototype.$EventBus = new Vue();
 Vue.config.productionTip = false;
 Vue.use(Vuetify);
 export default new Vuetify({

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,6 @@ import "roboto-fontface/css/roboto/roboto-fontface.css";
 import "@mdi/font/css/materialdesignicons.css";
 import Vuetify from "vuetify";
 
-Vue.prototype.$EventBus = new Vue();
 Vue.config.productionTip = false;
 Vue.use(Vuetify);
 export default new Vuetify({


### PR DESCRIPTION
Issues fixed by Aug.12.2021:

1. When slide Zoom bar: the "Grid size" value shows on the button.
2. When turning off 'Enable Automatic Grid', the Grid size value will change with the grid setting bar  
2. Added Tooltip to Grid settings: when moving the mouse to the pink grid setting on the top right, the 'Tooltip' will show
