### PR TITLE
Fix for #445

### DIFF
--- a/src/app/core/device.js
+++ b/src/app/core/device.js
@@ -854,6 +854,7 @@ export default class Device {
     createNewLayerBlock() {
         let flowlayer = new Layer({ z_offset: 0, flip: false }, "flow" + this.__layerBlockIndex.toString(), "FLOW", this.__layerBlockIndex.toString());
         let controllayer = new Layer({ z_offset: 0, flip: false }, "control" + this.__layerBlockIndex.toString(), "CONTROL", this.__layerBlockIndex.toString());
+                
         //TODO: remove cell layer from the whole system
         let cell = new Layer({ z_offset: 0, flip: false }, "cell" + this.__layerBlockIndex.toString(), "FLOW", this.__layerBlockIndex.toString());
 

--- a/src/app/view/viewManager.js
+++ b/src/app/view/viewManager.js
@@ -291,6 +291,8 @@ export default class ViewManager {
      */
     createNewLayerBlock() {
         let newlayers = Registry.currentDevice.createNewLayerBlock();
+        newlayers[0].color = "indigo";
+        newlayers[1].color = "red";
 
         //Find all the edge features
         let edgefeatures = [];


### PR DESCRIPTION
Added default colors to createNewLayerBlock() in viewManager to account for missing colors in the entire block. While this needs to get complete removed, it is causing the live version to fall apart (#445 ). 