### PR TITLE
Added the Error Message generation into the export utils.

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -8,7 +8,8 @@ test_patterns = [
 exclude_patterns = [
   "lib/**",
   "orbit_bundle.js",
-  "public/**"
+  "public/**",
+  "cc/**"
 ]
 
 [[analyzers]]

--- a/src/app/core/device.ts
+++ b/src/app/core/device.ts
@@ -20,6 +20,7 @@ import * as IOUtils from "../utils/ioUtils";
 import DeviceUtils from "@/app/utils/deviceUtils";
 import { ComponentAPI } from "@/componentAPI";
 import MapUtils from "../utils/mapUtils";
+import { SerializationError } from "../utils/exportUtils";
 
 /**
  * The Device stores information about a design.
@@ -469,10 +470,19 @@ export default class Device {
      * @returns {Array<ComponentInterchangeV1>}
      * @memberof Device
      */
-    __componentsToInterchangeV1(): Array<ComponentInterchangeV1> {
+    __componentsToInterchangeV1(errorList: Array<SerializationError>): Array<ComponentInterchangeV1> {
         let output: Array<ComponentInterchangeV1> = [];
         for (let i in this.__components) {
-            output.push(this.__components[i].toInterchangeV1());
+            try {
+                output.push(this.__components[i].toInterchangeV1());
+            }
+            catch (e) {
+                errorList.push(new SerializationError(
+                    e.message,
+                    "Component " + this.__components[i].name + " could not be converted to InterchangeV1",
+                    JSON.stringify(this.__components[i]),
+                ));
+            }
         }
         return output;
     }
@@ -481,15 +491,23 @@ export default class Device {
      * @returns {Array} Returns an array with the connections
      * @memberof Device
      */
-    __connectionToInterchangeV1(): Array<ConnectionInterchangeV1_2> {
+    __connectionToInterchangeV1(errorList: Array<SerializationError>): Array<ConnectionInterchangeV1_2> {
         let output: Array<ConnectionInterchangeV1_2> = [];
         for (let i in this.__connections) {
-            output.push(this.__connections[i].toInterchangeV1());
+            try {
+                output.push(this.__connections[i].toInterchangeV1());
+            } catch (e) {
+                errorList.push(new SerializationError(
+                    e.message,
+                    "Connection " + this.__connections[i].name + " could not be converted to InterchangeV1",
+                    JSON.stringify(this.__connections[i]),
+                ));
+            }
         }
         return output;
     }
 
-    __valvesToInterchangeV1(): Array<ValveInterchangeV1_2> {
+    __valvesToInterchangeV1(errorList: Array<SerializationError>): Array<ValveInterchangeV1_2> {
         let output: Array<ValveInterchangeV1_2> = [];
         this.__valveMap.forEach((target, valve) => {
             let valve_type = this.__valveTypeMap.get(valve);
@@ -524,10 +542,18 @@ export default class Device {
      * @return {Array<LayerInterchangeV1>} Returns an array with the layers
      * @memberof Device
      */
-    __layersToInterchangeV1(): Array<LayerInterchangeV1> {
+    __layersToInterchangeV1(errorList: Array<SerializationError>): Array<LayerInterchangeV1> {
         const output: Array<LayerInterchangeV1> = [];
         for (const i in this.__layers) {
-            output.push(this.__layers[i].toInterchangeV1());
+            try {
+                output.push(this.__layers[i].toInterchangeV1());
+            } catch (e) {
+                errorList.push(new SerializationError(
+                    e.message,
+                    "Layer " + this.__layers[i].name + " could not be converted to InterchangeV1",
+                    JSON.stringify(this.__layers[i])
+                ));
+            }
         }
         return output;
     }
@@ -579,7 +605,7 @@ export default class Device {
      * @returns {Device} Returns an Device object in Interchange V1 format
      * @memberof Device
      */
-    toInterchangeV1(): DeviceInterchangeV1 {
+    toInterchangeV1(errorList: Array<SerializationError>): DeviceInterchangeV1 {
         let output: DeviceInterchangeV1 = {
             name: this.__name,
             params: {
@@ -587,17 +613,17 @@ export default class Device {
                 length: this.getYSpan()
             },
             //TODO: Use this to dynamically create enough layers to scroll through
-            layers: this.__layersToInterchangeV1(),
-            components: this.__componentsToInterchangeV1(),
-            connections: this.__connectionToInterchangeV1(),
-            valves: this.__valvesToInterchangeV1(),
+            layers: this.__layersToInterchangeV1(errorList),
+            components: this.__componentsToInterchangeV1(errorList),
+            connections: this.__connectionToInterchangeV1(errorList),
+            valves: this.__valvesToInterchangeV1(errorList),
             version: "1",
             groups: this.__groupsToJSON()
         };
         return output;
     }
 
-    toInterchangeV1_1(): DeviceInterchangeV1_1 {
+    toInterchangeV1_1(errorList: Array<SerializationError>): DeviceInterchangeV1_1 {
         let output: DeviceInterchangeV1_1 = {
             name: this.__name,
             params: {
@@ -605,9 +631,9 @@ export default class Device {
                 length: this.getYSpan()
             },
             //TODO: Use this to dynamically create enough layers to scroll through
-            layers: this.__layersToInterchangeV1(),
-            components: this.__componentsToInterchangeV1(),
-            connections: this.__connectionToInterchangeV1(),
+            layers: this.__layersToInterchangeV1(errorList),
+            components: this.__componentsToInterchangeV1(errorList),
+            connections: this.__connectionToInterchangeV1(errorList),
             version: "1.1",
             groups: this.__groupsToJSON()
         };

--- a/src/app/core/device.ts
+++ b/src/app/core/device.ts
@@ -477,6 +477,7 @@ export default class Device {
                 output.push(this.__components[i].toInterchangeV1());
             }
             catch (e) {
+                console.error(e);
                 errorList.push(new SerializationError(
                     e.message,
                     "Component " + this.__components[i].name + " could not be converted to InterchangeV1",
@@ -497,6 +498,7 @@ export default class Device {
             try {
                 output.push(this.__connections[i].toInterchangeV1());
             } catch (e) {
+                console.error(e);
                 errorList.push(new SerializationError(
                     e.message,
                     "Connection " + this.__connections[i].name + " could not be converted to InterchangeV1",
@@ -548,6 +550,7 @@ export default class Device {
             try {
                 output.push(this.__layers[i].toInterchangeV1());
             } catch (e) {
+                console.error(e);
                 errorList.push(new SerializationError(
                     e.message,
                     "Layer " + this.__layers[i].name + " could not be converted to InterchangeV1",

--- a/src/app/core/device.ts
+++ b/src/app/core/device.ts
@@ -480,7 +480,7 @@ export default class Device {
                 console.error(e);
                 errorList.push(new SerializationError(
                     e.message,
-                    "Component " + this.__components[i].name + " could not be converted to InterchangeV1",
+                    `Component ${this.__components[i].id} could not be converted to InterchangeV1`,
                     JSON.stringify(this.__components[i]),
                 ));
             }
@@ -501,7 +501,7 @@ export default class Device {
                 console.error(e);
                 errorList.push(new SerializationError(
                     e.message,
-                    "Connection " + this.__connections[i].name + " could not be converted to InterchangeV1",
+                   `Connection : ${this.__connections[i].id} could not be converted to InterchangeV1`,
                     JSON.stringify(this.__connections[i]),
                 ));
             }
@@ -511,18 +511,27 @@ export default class Device {
 
     __valvesToInterchangeV1(errorList: Array<SerializationError>): Array<ValveInterchangeV1_2> {
         let output: Array<ValveInterchangeV1_2> = [];
-        this.__valveMap.forEach((target, valve) => {
-            let valve_type = this.__valveTypeMap.get(valve);
+        this.__valveMap.forEach((target, valveID) => {
+            let valve_type = this.__valveTypeMap.get(valveID);
             if(valve_type === undefined) {
-                console.error("Valve type not found for valve: " + valve + " , setting default to NORMALLY_OPEN");
+                console.warn("Valve type not found for valve: " + valveID + " , setting default to NORMALLY_OPEN");
                 valve_type = ValveType.NORMALLY_OPEN;
             }
-            output.push({
-                componentid: valve,
-                connectionid: target,
-                type: valve_type,
-                params: {}
-            });
+            try {
+                output.push({
+                    componentid: valveID,
+                    connectionid: target,
+                    type: valve_type,
+                    params: {}
+                });
+            } catch (e) {
+                console.error(e);
+                errorList.push(new SerializationError(
+                    e.message,
+                    `Valve : ${valveID}  could not be converted to InterchangeV1`,
+                    JSON.stringify(valveID),
+                ));
+            }
         });
         return output;
     }
@@ -553,7 +562,7 @@ export default class Device {
                 console.error(e);
                 errorList.push(new SerializationError(
                     e.message,
-                    "Layer " + this.__layers[i].name + " could not be converted to InterchangeV1",
+                    `Layer ${this.__layers[i].id} could not be converted to InterchangeV1`,
                     JSON.stringify(this.__layers[i])
                 ));
             }

--- a/src/app/manufacturing/cncGenerator.ts
+++ b/src/app/manufacturing/cncGenerator.ts
@@ -15,7 +15,7 @@ import { DFMType } from "./manufacturingInfo";
 export default class CNCGenerator {
     __device: Device;
     __viewManagerDelegate: viewManager;
-    __svgData: Map<String, string>;
+    __svgData: Map<string, string>;
 
     /**
      * Default Constructor of GNCGenerator object.
@@ -34,7 +34,7 @@ export default class CNCGenerator {
      * @returns {}
      * @memberof CNCGenerator
      */
-    getSVGOutputs(): Map<String, string> {
+    getSVGOutputs(): Map<string, string> {
         return this.__svgData;
     }
 

--- a/src/app/manufacturing/laserCuttingGenerator.ts
+++ b/src/app/manufacturing/laserCuttingGenerator.ts
@@ -34,7 +34,7 @@ export default class LaserCuttingGenerator {
      * @returns Returns the SVG data
      * @memberof LaserCuttingGenerator
      */
-    getSVGOutputs(): Map<String, string> {
+    getSVGOutputs(): Map<string, string> {
         return this.__svgData;
     }
 

--- a/src/app/manufacturing/manufacturingLayer.ts
+++ b/src/app/manufacturing/manufacturingLayer.ts
@@ -11,7 +11,7 @@ import { ToolPaperObject } from "../core/init";
  */
 export default class ManufacturingLayer {
     __features: Array<ToolPaperObject>;
-    __name: String;
+    __name: string;
     __paperGroup: paper.Group;
     __flip: boolean;
 
@@ -19,7 +19,7 @@ export default class ManufacturingLayer {
      * Default Constructor for the Manufacturing Layer
      * @param {String} name Name of the field
      */
-    constructor(name: String, flip = false) {
+    constructor(name: string, flip = false) {
         this.__features = [];
         this.__name = name;
         this.__paperGroup = new paper.Group();
@@ -31,7 +31,7 @@ export default class ManufacturingLayer {
      * @return {String} Returns the name of the field
      * @memberof ManufacturingLayer
      */
-    get name(): String {
+    get name(): string {
         return this.__name;
     }
 

--- a/src/app/utils/exportUtils.ts
+++ b/src/app/utils/exportUtils.ts
@@ -31,7 +31,7 @@ export class SerializationError {
      * @type {*}
      * @memberof SerializationError
      */
-    public element: any;
+    public element: string;
 
     /**
      * The JSON data that was being processed when the error occurred.
@@ -41,17 +41,31 @@ export class SerializationError {
      */
     public jsonData: string;
 
-    constructor(message: string, element: any, jsonData: any) {
+    /**
+     * Creates an instance of SerializationError.
+     * @param {string} message
+     * @param {string} element
+     * @param {string} jsonData
+     * @memberof SerializationError
+     */
+    constructor(message: string, element: string, jsonData: string) {
         this.message = message;
         this.element = element;
         this.jsonData = jsonData;
     }
 
+    /**
+     * Converts the error to a string.
+     * suitable for display to the user. or in a log file.
+     *
+     * @returns {string}
+     * @memberof SerializationError
+     */
     toText(): string {
-        let ret = "Error: " + this.message + "\n";
-        ret += "Element: " + this.element + "\n";
+        let ret = `Error: ${this.message} \n`;
+        ret += `Element: ${this.element} \n`;
         ret += "\`\`\`\n";
-        ret += "JSON Data: " + this.jsonData + "\n";
+        ret += `JSON Data: ${this.jsonData} \n`;
         ret += "\`\`\`\n";
 
         return ret;

--- a/src/app/utils/exportUtils.ts
+++ b/src/app/utils/exportUtils.ts
@@ -16,6 +16,49 @@ import {
 import ConnectionTarget from "../core/connectionTarget";
 import GeometryElement from "../core/geometryElement";
 
+export class SerializationError {
+    /**
+     * Error message for the user.
+     *
+     * @type {string}
+     * @memberof SerializationError
+     */
+    public message: string;
+
+    /**
+     * The element that caused the error.
+     * TBD on how ot use this in the future.
+     * @type {*}
+     * @memberof SerializationError
+     */
+    public element: any;
+
+    /**
+     * The JSON data that was being processed when the error occurred.
+     *
+     * @type {string}
+     * @memberof SerializationError
+     */
+    public jsonData: string;
+
+    constructor(message: string, element: any, jsonData: any) {
+        this.message = message;
+        this.element = element;
+        this.jsonData = jsonData;
+    }
+
+    toText(): string {
+        let ret = "Error: " + this.message + "\n";
+        ret += "Element: " + this.element + "\n";
+        ret += "\`\`\`\n";
+        ret += "JSON Data: " + this.jsonData + "\n";
+        ret += "\`\`\`\n";
+
+        return ret;
+    }
+}
+
+
 export default class ExportUtils {
 
     /**
@@ -26,7 +69,7 @@ export default class ExportUtils {
      * @returns {InterchangeV1_2}
      * @memberof ExportUtils
      */
-    static toInterchangeV1_2(viewManagerDelegate: ViewManager): InterchangeV1_2 {
+    static toInterchangeV1_2(viewManagerDelegate: ViewManager, errorList:SerializationError[]): InterchangeV1_2 {
         if(viewManagerDelegate.currentDevice === null) {
             throw new Error("No device selected");
         }
@@ -35,7 +78,7 @@ export default class ExportUtils {
         for (let i = 0; i < viewManagerDelegate.renderLayers.length; i++) {
             renderLayers.push(viewManagerDelegate.renderLayers[i].toInterchangeV1());
         }
-        const device = viewManagerDelegate.currentDevice.toInterchangeV1();
+        const device = viewManagerDelegate.currentDevice.toInterchangeV1(errorList);
         
         const valvemap = {};
         const valvetypemap = {};

--- a/src/app/utils/exportUtils.ts
+++ b/src/app/utils/exportUtils.ts
@@ -62,11 +62,12 @@ export class SerializationError {
      * @memberof SerializationError
      */
     toText(): string {
-        let ret = `Error: ${this.message} \n`;
-        ret += `Element: ${this.element} \n`;
+        let ret = `Error: ${this.message}\n`;
+        ret += `Element: ${this.element}\n`;
+        ret += "JSON Data:\n";
         ret += "\`\`\`\n";
-        ret += `JSON Data: ${this.jsonData} \n`;
-        ret += "\`\`\`\n";
+        ret += this.jsonData;
+        ret += "\n\`\`\`\n";
 
         return ret;
     }

--- a/src/app/view/paperView.ts
+++ b/src/app/view/paperView.ts
@@ -461,7 +461,7 @@ export default class PaperView {
      * @returns {void}
      * @memberof PaperView
      */
-    setResizeFunction(func: Function | null): void {
+    setResizeFunction(func: () => void | null): void {
         if (this.canvas === null) {
             throw new Error("Canvas is null");
         }

--- a/src/app/view/viewManager.ts
+++ b/src/app/view/viewManager.ts
@@ -1717,8 +1717,8 @@ export default class ViewManager {
         if(this.currentDevice === null){
             throw new Error("No device loaded");
         }
-        let errorList: Array<SerializationError> = [];
-        let json = new Blob([JSON.stringify(this.generateExportJSON(errorList))], {
+        const errorList: Array<SerializationError> = [];
+        const json = new Blob([JSON.stringify(this.generateExportJSON(errorList))], {
             type: "application/json"
         });
         saveAs(json, this.currentDevice.name + ".json");
@@ -1729,7 +1729,7 @@ export default class ViewManager {
             for (const error of errorList) {
                 errorString += error.toText() + "\n\n";
             }
-            let errorBlob = new Blob([errorString], {
+            const errorBlob = new Blob([errorString], {
                 type: "text/plain"
             });
             saveAs(errorBlob, this.currentDevice.name + "_errors.txt");

--- a/src/components/ManufacturingPanel.vue
+++ b/src/components/ManufacturingPanel.vue
@@ -88,10 +88,7 @@ export default {
     },
     methods: {
         downloadJSON() {
-            let json = new Blob([JSON.stringify(this.viewManagerRef.generateExportJSON())], {
-                type: "application/json"
-            });
-            saveAs(json, Registry.currentDevice.name + ".json");
+            this.viewManagerRef.downloadJSON();
         },
         downloadSVG() {
             let svgs = this.viewManagerRef.layersToSVGStrings();


### PR DESCRIPTION
This PR addresses the issues where the browser code crashes during serialization when encountering objects with insufficient data.

Since the typescript transpiler enforces completeness in the data. We added the ability to add and serialize error messages. Final output generates a nice long text file that also is downloaded if any errors were found. 

This partially addresses #475 in terms of application behavior but does not fix the underlying problem.